### PR TITLE
92: Urgent Astronomy pipeline bugfix

### DIFF
--- a/docker/astronomy.Dockerfile
+++ b/docker/astronomy.Dockerfile
@@ -10,16 +10,18 @@ COPY requirements.txt ./
 # AWS linux links against an older PGSQL version that only supports MD5 auth
 # SCRAM auth is used by our Python drivers, so it's easier to do this and just update libpq
 # the line below enables postgresql10 specifically as the default postgresql package is too old
-RUN yum install -y gcc \
-&& pip install -r requirements.txt \
-&& yum clean all
+RUN yum install -y gcc
+RUN pip install -r requirements.txt
+RUN yum clean all
 
+RUN mkdir src
 # Copy only the files you need into src/
-COPY src/extract_astronomy_data.py   .
-COPY src/transform_astronomy_data.py .
-COPY src/load_astronomy_data.py      .
-COPY src/pipeline_astronomy_data.py  .
-COPY src/astronomy_utils.py .
+COPY src/__init__.py                 src/
+COPY src/extract_astronomy_data.py   src/
+COPY src/transform_astronomy_data.py src/
+COPY src/load_astronomy_data.py      src/
+COPY src/pipeline_astronomy_data.py  src/
+COPY src/astronomy_utils.py          src/
 
 # Tell Lambda to invoke the handler inside the src package
-CMD ["pipeline_astronomy_data.handler"]
+CMD ["src.pipeline_astronomy_data.handler"]

--- a/docker/astronomy.Dockerfile
+++ b/docker/astronomy.Dockerfile
@@ -14,8 +14,8 @@ RUN yum install -y gcc
 RUN pip install -r requirements.txt
 RUN yum clean all
 
-RUN mkdir src
 # Copy only the files you need into src/
+RUN mkdir src
 COPY src/__init__.py                 src/
 COPY src/extract_astronomy_data.py   src/
 COPY src/transform_astronomy_data.py src/

--- a/docker/deploy_astronomy.sh
+++ b/docker/deploy_astronomy.sh
@@ -4,6 +4,7 @@ aws ecr get-login-password \
 | docker login \
   --username AWS \
   --password-stdin 129033205317.dkr.ecr.eu-west-2.amazonaws.com
+echo "AWS authenticated"
 
 # 2) Build ARM64 image
 docker buildx build . \
@@ -11,6 +12,15 @@ docker buildx build . \
   --platform linux/arm64 \
   --file docker/astronomy.Dockerfile \
   --tag 129033205317.dkr.ecr.eu-west-2.amazonaws.com/c18-starwatch-ecr:astronomy_pipeline
+echo "Building new image"
 
 # 3) Push it up to ECR
 docker push 129033205317.dkr.ecr.eu-west-2.amazonaws.com/c18-starwatch-ecr:astronomy_pipeline
+echo "Image pushed to AWS"
+
+# 4) Update the lambda function code with the new image
+aws lambda update-function-code \
+  --function-name c18-starwatch-etl-lambda \
+  --image-uri 129033205317.dkr.ecr.eu-west-2.amazonaws.com/c18-starwatch-ecr:astronomy_pipeline \
+  --region eu-west-2
+echo "Lambda function code updated"

--- a/src/astronomy_utils.py
+++ b/src/astronomy_utils.py
@@ -1,6 +1,7 @@
 """Utilities file for proper namespace hygiene"""
 import os
 import base64
+from typing import Dict
 
 DATA_FILEPATH = '../data/'
 
@@ -15,7 +16,7 @@ def construct_astronomy_api_auth() -> str:
     auth_string = base64.b64encode(user_pass.encode()).decode()
     return auth_string
 
-def make_request_headers() -> dict[str:str]:
+def make_request_headers() -> Dict[str, str]:
     """
     WARN!!! Assumes the .env is loaded and has values for:
         - APPLICATION_ID

--- a/src/extract_astronomy_data.py
+++ b/src/extract_astronomy_data.py
@@ -8,7 +8,7 @@ import psycopg2
 import requests
 from dotenv import load_dotenv
 
-from astronomy_utils import make_request_headers
+from src.astronomy_utils import make_request_headers
 
 def get_db_connection() -> psycopg2.extensions.connection:
     """

--- a/src/extract_astronomy_data.py
+++ b/src/extract_astronomy_data.py
@@ -8,7 +8,7 @@ import psycopg2
 import requests
 from dotenv import load_dotenv
 
-from src.astronomy_utils import make_request_headers
+from astronomy_utils import make_request_headers
 
 def get_db_connection() -> psycopg2.extensions.connection:
     """

--- a/src/load_astronomy_data.py
+++ b/src/load_astronomy_data.py
@@ -11,7 +11,7 @@ from sqlalchemy import create_engine, text, Engine
 import pandas as pd
 from dotenv import load_dotenv
 
-from transform_astronomy_data import get_json_data, filter_data
+from src.transform_astronomy_data import get_json_data, filter_data
 
 FILE_PATH = "../data/planetary_data.json"
 

--- a/src/pipeline_astronomy_data.py
+++ b/src/pipeline_astronomy_data.py
@@ -3,10 +3,10 @@ import datetime
 
 from dotenv import load_dotenv
 
-from extract_astronomy_data import get_db_connection, get_planetary_positions, get_date_range
-from transform_astronomy_data import filter_data
-from load_astronomy_data import main
-from astronomy_utils import make_request_headers
+from src.extract_astronomy_data import get_db_connection, get_planetary_positions, get_date_range
+from src.transform_astronomy_data import filter_data
+from src.load_astronomy_data import main
+from src.astronomy_utils import make_request_headers
 
 def run_pipeline():
     """Runs the astronomy pipeline from start to finish"""

--- a/test/__init__.py
+++ b/test/__init__.py
@@ -1,0 +1,1 @@
+"""Defines test as its own module in the project"""

--- a/test/test_transform_weather.py
+++ b/test/test_transform_weather.py
@@ -3,7 +3,7 @@ import pytest
 import pandas as pd
 from datetime import date
 
-from src.transform_weather import transform_current_data, transform_daily_data, transform_hourly_data
+from src transform_weather import transform_current_data, transform_daily_data, transform_hourly_data
 
 
 @pytest.fixture


### PR DESCRIPTION
# Description

This is a longer PR description to define the problem we were having and how it was solved. It also includes a small update and bugfixes to the associated dockerfile and shell script.

In our Python code, we used relative rather than absolute import paths. This makes our code cleaner and easier to work with, but due to our file structures we needed to work across 2 modules: `src` and `test`.

Qualifying the relative paths with `src` allowed the test suite to run, but broke the pipeline itself. Removing the `src` qualifier fixed the pipeline, but broke the test suite. These issues caused a problem in that we were constantly swapping between the two.

The fix involves qualifying *all* paths with `src` always and invoking the pipeline as a module rather than a script directly:
`python3 -m src.pipeline_astronomy_data` instead of `python3 src/pipeline_astronomy_data.py`.
The -m flag passes *module information* to Python, allowing it to properly resolve the import paths we use in our source code.

Closes: #92

## Type of change

- [x] Bug fix (change which fixes an issue)
- [ ] New feature (change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes

# Mentions
@emily-james
@CoDinAIy
@rosie-13
@mercuridi
